### PR TITLE
Fix/ansible tier4 hdr camera driver

### DIFF
--- a/ansible/roles/artifacts/defaults/main.yaml
+++ b/ansible/roles/artifacts/defaults/main.yaml
@@ -1,0 +1,1 @@
+script_download_dir: /tmp

--- a/ansible/roles/artifacts/tasks/main.yaml
+++ b/ansible/roles/artifacts/tasks/main.yaml
@@ -1,0 +1,80 @@
+# tensorrt_yolox
+- name: Create tensorrt_yolox directory inside {{ data_dir }}
+  ansible.builtin.file:
+    path: "{{ data_dir }}/tensorrt_yolox"
+    mode: "755"
+    state: directory
+
+- name: Download tensorrt_yolox/yolox-tiny.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-tiny.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-tiny.onnx"
+    mode: "644"
+    checksum: sha256:471a665f4243e654dff62578394e508db22ee29fe65d9e389dfc3b0f2dee1255
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.onnx"
+    mode: "644"
+    checksum: sha256:36b0832177b01e6b278e00c7369f1de71e616c36261cbae50f0753d41289da01
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/yolox-sPlus-opt.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: sha256:b9e9d7da33342262ccaea4469b4d02b8abb32b6d7bf737f9e0883fece1b8f580
+
+- name: Download tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_yolox_s/v1/yolox-sPlus-T4-960x960-pseudo-finetune.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.onnx"
+    mode: "644"
+    checksum: sha256:f5054e8a890c3be86dc1b4b89a5a36fb2279d4f6110b0159e793be062641bf65
+
+- name: Download tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_yolox_s/v1/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-T4-960x960-pseudo-finetune.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: sha256:cc378d327db5616b0b3a4d077bf37100c25a50ecd22d2b542f54098da100f34c
+
+- name: Download tensorrt_yolox/label.txt
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/label.txt
+    dest: "{{ data_dir }}/tensorrt_yolox/label.txt"
+    mode: "644"
+    checksum: sha256:3540a365bfd6d8afb1b5d8df4ec47f82cb984760d3270c9b41dbbb3422d09a0c
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx"
+    mode: "644"
+    checksum: sha256:73b3812432cedf65cebf02ca4cb630542fc3b1671c4c0fbf7cee50fa38e416a8
+
+- name: Download tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table
+    dest: "{{ data_dir }}/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.EntropyV2-calibration.table"
+    mode: "644"
+    checksum: sha256:28cd6524d4bcdb2809592a225d28330433e58dc02c92169ea555b44c1a51a584
+
+- name: Download tensorrt_yolox/semseg_color_map.csv
+  become: true
+  ansible.builtin.get_url:
+    url: https://awf.ml.dev.web.auto/perception/models/object_detection_semseg_yolox_s/v1/semseg_color_map.csv
+    dest: "{{ data_dir }}/tensorrt_yolox/semseg_color_map.csv"
+    mode: "644"
+    checksum: sha256:3d93ca05f31b63424d7d7246a01a2365953705a0ed3323ba5b6fddd744a4bfea
+
+

--- a/ansible/roles/tier4_hdr_camera_driver/defaults/main.yaml
+++ b/ansible/roles/tier4_hdr_camera_driver/defaults/main.yaml
@@ -1,3 +1,3 @@
-camera_driver_repo: https://api.github.com/repos/tier4/tier4_automotive_hdr_camera/releases/latest
+camera_driver_repo: https://api.github.com/repos/tier4/tier4_automotive_hdr_camera/releases/142093397
 camera_driver_download_dir: /tmp
 exposure_time: 11000

--- a/ansible/roles/tier4_hdr_camera_driver/tasks/main.yaml
+++ b/ansible/roles/tier4_hdr_camera_driver/tasks/main.yaml
@@ -3,22 +3,12 @@
     url: "{{ camera_driver_repo }}"
   register: github_api_return_info
 
-- name: Check if GitHub API return is valid
-  fail:
-    msg: "Failed to fetch data from GitHub API."
-  when: github_api_return_info.status != 200
-
 - name: Parse download URL for driver
   loop: "{{ github_api_return_info.json.assets }}"
   ansible.builtin.set_fact:
     driver_deb_download_url: "{{ item.browser_download_url }}"
     driver_deb_name: "{{ item.name }}"
-  when: item.name | regex_search('tier4-camera-drivers-for-anvil.tar.gz')
-
-- name: Ensure driver_deb_download_url is defined
-  fail:
-    msg: "driver_deb_download_url is not defined. Check the regex or GitHub API response."
-  when: driver_deb_download_url is not defined
+  when: item.name | regex_search('tier4-camera-gmsl_(.+)_arm64.deb')
 
 - name: Parse download URL for SDK
   loop: "{{ github_api_return_info.json.assets }}"
@@ -27,32 +17,11 @@
     sdk_deb_name: "{{ item.name }}"
   when: item.name | regex_search('t4cam_sdk-(.+)-rqx58g.deb')
 
-- name: Download driver tar.gz file from public repo
-  ansible.builtin.get_url:
+- name: Download driver deb file from public repo
+  ansible.builtin.uri:
     url: "{{ driver_deb_download_url }}"
     dest: "{{ camera_driver_download_dir }}/{{ driver_deb_name }}"
     mode: 0644
-
-- name: Extract driver tar.gz file
-  ansible.builtin.unarchive:
-    src: "{{ camera_driver_download_dir }}/{{ driver_deb_name }}"
-    dest: "{{ camera_driver_download_dir }}"
-    remote_src: yes
-
-- name: Ensure install.sh has execute permission
-  ansible.builtin.file:
-    path: "{{ camera_driver_download_dir }}/tier4-camera-drivers-for-anvil/install.sh"
-    mode: '0755'
-    state: file
-
-- name: Fix shebang line in install.sh
-  ansible.builtin.shell: |
-    sed -i '1s/^#\/bin\/bash$/#!\/bin\/bash/' {{ camera_driver_download_dir }}/tier4-camera-drivers-for-anvil/install.sh
-
-- name: Run installation script
-  command: "echo $EUID && c {{ camera_driver_download_dir }}/tier4-camera-drivers-for-anvil/install.sh"
-  become: true
-  become_user: root
 
 - name: Download SDK deb file from public repo
   ansible.builtin.uri:
@@ -76,12 +45,21 @@
 - name: Setup camera driver and SDK
   become: true
   block:
+    - name: Install driver from deb file
+      ansible.builtin.apt:
+        deb: "{{ camera_driver_download_dir }}/{{ driver_deb_name }}"
+        state: present
     - name: Post process
       ansible.builtin.shell:
         cmd: |
           /opt/nvidia/jetson-io/config-by-hardware.py -n 2="TIERIV ISX021 GMSL2 Camera Device Tree Overlay"
         # noqa no-changed-when
         # TODO: check dtb file
+    - name: Install SDK from deb file
+      ansible.builtin.apt:
+        deb: "{{ camera_driver_download_dir }}/{{ sdk_deb_name }}"
+        state: present
+      when: sdk_deb_download_url is defined
 
 - name: Setup C1 configuration
   block:

--- a/ansible/roles/tier4_hdr_camera_driver/tasks/main.yaml
+++ b/ansible/roles/tier4_hdr_camera_driver/tasks/main.yaml
@@ -3,12 +3,22 @@
     url: "{{ camera_driver_repo }}"
   register: github_api_return_info
 
+- name: Check if GitHub API return is valid
+  fail:
+    msg: "Failed to fetch data from GitHub API."
+  when: github_api_return_info.status != 200
+
 - name: Parse download URL for driver
   loop: "{{ github_api_return_info.json.assets }}"
   ansible.builtin.set_fact:
     driver_deb_download_url: "{{ item.browser_download_url }}"
     driver_deb_name: "{{ item.name }}"
-  when: item.name | regex_search('tier4-camera-gmsl_(.+)_arm64.deb')
+  when: item.name | regex_search('tier4-camera-drivers-for-anvil.tar.gz')
+
+- name: Ensure driver_deb_download_url is defined
+  fail:
+    msg: "driver_deb_download_url is not defined. Check the regex or GitHub API response."
+  when: driver_deb_download_url is not defined
 
 - name: Parse download URL for SDK
   loop: "{{ github_api_return_info.json.assets }}"
@@ -17,11 +27,32 @@
     sdk_deb_name: "{{ item.name }}"
   when: item.name | regex_search('t4cam_sdk-(.+)-rqx58g.deb')
 
-- name: Download driver deb file from public repo
-  ansible.builtin.uri:
+- name: Download driver tar.gz file from public repo
+  ansible.builtin.get_url:
     url: "{{ driver_deb_download_url }}"
     dest: "{{ camera_driver_download_dir }}/{{ driver_deb_name }}"
     mode: 0644
+
+- name: Extract driver tar.gz file
+  ansible.builtin.unarchive:
+    src: "{{ camera_driver_download_dir }}/{{ driver_deb_name }}"
+    dest: "{{ camera_driver_download_dir }}"
+    remote_src: yes
+
+- name: Ensure install.sh has execute permission
+  ansible.builtin.file:
+    path: "{{ camera_driver_download_dir }}/tier4-camera-drivers-for-anvil/install.sh"
+    mode: '0755'
+    state: file
+
+- name: Fix shebang line in install.sh
+  ansible.builtin.shell: |
+    sed -i '1s/^#\/bin\/bash$/#!\/bin\/bash/' {{ camera_driver_download_dir }}/tier4-camera-drivers-for-anvil/install.sh
+
+- name: Run installation script
+  command: "echo $EUID && c {{ camera_driver_download_dir }}/tier4-camera-drivers-for-anvil/install.sh"
+  become: true
+  become_user: root
 
 - name: Download SDK deb file from public repo
   ansible.builtin.uri:
@@ -45,21 +76,12 @@
 - name: Setup camera driver and SDK
   become: true
   block:
-    - name: Install driver from deb file
-      ansible.builtin.apt:
-        deb: "{{ camera_driver_download_dir }}/{{ driver_deb_name }}"
-        state: present
     - name: Post process
       ansible.builtin.shell:
         cmd: |
           /opt/nvidia/jetson-io/config-by-hardware.py -n 2="TIERIV ISX021 GMSL2 Camera Device Tree Overlay"
         # noqa no-changed-when
         # TODO: check dtb file
-    - name: Install SDK from deb file
-      ansible.builtin.apt:
-        deb: "{{ camera_driver_download_dir }}/{{ sdk_deb_name }}"
-        state: present
-      when: sdk_deb_download_url is defined
 
 - name: Setup C1 configuration
   block:

--- a/ansible/setup.yaml
+++ b/ansible/setup.yaml
@@ -19,6 +19,7 @@
         [Warning] Do you want to configure the network? This configuration may overwrite the IP address of the specific network interface [y/N]
       private: false
   roles:
+    - role: artifacts
     - role: autoware
     - role: cuda
     - role: cyclonedds

--- a/autoware.repos
+++ b/autoware.repos
@@ -58,3 +58,11 @@ repositories:
     type: git
     url: https://github.com/tier4/tensorrt_cmake_module.git
     version: main
+  demos:
+    type: git
+    url: https://github.com/ros2/demos.git
+    version: humble
+  autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: main

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -49,7 +49,7 @@ export PATH="$HOME/.local/bin:$PATH"
 echo -e "\e[36mRunning ansible playbook to setup ECU.\e[0m"
 
 # Run ansible
-if ansible-playbook "${SCRIPT_DIR}"/ansible/setup.yaml --ask-become-pass; then
+if ansible-playbook "${SCRIPT_DIR}"/ansible/setup.yaml --ask-become-pass --extra-vars data_dir=$HOME/autoware_data; then
     echo -e "\e[32mCompleted.\e[0m"
     exit 0
 else


### PR DESCRIPTION
## Enviroment
Ubuntu 18.04
ADLINK RQX-58G (L4T R32.6.1)

## Description
I ran `./setup-dev-env.sh` to setup ECU, and got the following error.
![url_err](https://github.com/MapIV/edge-auto-jetson/assets/110436081/93467ac3-663f-4df4-b17d-776904c049e7)

The file referenced by driver_deb_download_url was intended exclusively for the CTI Anvil platform, and therefore did not work with the RQX-58G. Consequently, it was changed to the URL for the latest supported version of the camera driver for RQX-58G, which is[ v1.4.3](https://github.com/tier4/tier4_automotive_hdr_camera/releases/tag/v1.4.3)tar.gz.

## Tests performed
Build was succesful in my environment.
